### PR TITLE
ZCS-10594/TSS-18404: Fix for emails not displaying correctly.

### DIFF
--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -170,11 +170,18 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
             @SuppressWarnings("deprecation")
             org.apache.xml.serialize.OutputFormat format = getOutputFormat();
 
-            //noinspection deprecation
-            org.apache.xml.serialize.HTMLSerializer serializer = getHTMLSerializer(out, format);
+            /* Selectively serialize the DocumentFragment only if doesn't
+             * contain any @ symbol which are media queries causing to
+             * whatever content is after @ symbol gets stripped off in the
+             * style tag.
+             * This is reported and accepted as a bug in the antisamy library #24.
+             *
+             */
             if (trimmedHtml.contains("@")) {
                 out = out.append(trimmedHtml);
             } else {
+                //noinspection deprecation
+                org.apache.xml.serialize.HTMLSerializer serializer = getHTMLSerializer(out, format);
                 serializer.serialize(dom);
             }
                     /*

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -172,8 +172,11 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
 
             //noinspection deprecation
             org.apache.xml.serialize.HTMLSerializer serializer = getHTMLSerializer(out, format);
-            serializer.serialize(dom);
-
+            if (trimmedHtml.contains("@")) {
+                out = out.append(trimmedHtml);
+            } else {
+                serializer.serialize(dom);
+            }
                     /*
                     * Get the String out of the StringWriter and rip out the XML
                     * declaration if the Policy says we should.


### PR DESCRIPTION
**Problem:**
Reported glassdoor E-mails not displaying correctly in the classic UI.

**Analysis:**
In the classic UI, investigated why the links as displayed in the screenshots are coming over the edge and the `CSS` rules are not getting applied to it. Found that the actual issue for the Glassdoor e-mails in the classic UI is causing due to the following `media queries` in the style tag:
```
@media not all and (pointer:coarse){.css-8=
bsfb:hover{background-color:#056b27;border-color:#056b27;color:#fff !import=
ant;}}
```

When I tried to remove the above code and imported the Mimes, all the new imported mimes were getting rendered properly. Looked into the `antisamy.xml` file and the tag and attribute policies related to style and media. I tried changing and removing the policies related to it but there was no effect of those.

- Tried upgrading `antisamy` to `1.6.3` but still having the same issue.
- Also, tried compiling and run `antisamy` with latest version of `org.apache.xml.serialize` but having the same issue.
- Tried `LSSerializer` which comes bundled with `Xerces` after serialisation it's giving the same output.

The problem is causing not because of the `OWASP` but it's in the `antisamy` library during the `serialization`. During `sanitization`, the above media queries were not removed but while the `antisamy` library tries to perform the `serialization` of the document fragment those media queries are getting stripped off. For `serialization` `antisamy` is dependent on another third-party library which is causing the issue `org.apache.xml.serialize.HTMLSerializer.`

This is reported and accepted as a bug in the `antisamy` library, so anything which comes ahead of the `@` symbol gets stripped out.
[Reported Bug](https://github.com/nahsra/antisamy/issues/24)
I have also updated the bug as per our issue.

In the `org.owasp.validator.html.scan.AntiSamyDOMScanner` class, I was having the expected string prior to `serialization` and after the `org.apache.xml.serialize.HTMLSerializer` has done the `serialization` to the `DocumentFragment` whatever it was after the `@` symbol got stripped off in the style tag.

**Fix:** Introduces an `if-else` condition to selectively serialize the `DocumentFragment` only if doesn't contain any `@` symbol otherwise append it to the `StringWriter`, which seems to fix our issue until we get a fix for bug from `antisamy`. Also, looking for an `HTMLSerializer` which can handle the media queries in the style sheet.

**Testing Done:**
- Written unit test case for verifying that media queries are not getting stripped off after the fix.
- Verified with the glassdoor mimes in the classic UI `CSS` is displaying properly after the fix.

**Related PRs:**
[Zimbra/zm-mailbox](https://github.com/Zimbra/zm-mailbox/pull/1150)
[ZimbraOS/zm-mailbox](https://github.com/ZimbraOS/zm-mailbox/pull/500)