### PR TITLE
ZBUG-2536: changed to remove @import

### DIFF
--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -68,6 +68,8 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
             Pattern.compile("[\\u0000-\\u001F\\uD800-\\uDFFF\\uFFFE-\\uFFFF&&[^\\u0009\\u000A\\u000D]]");
     private static final Pattern conditionalDirectives =
             Pattern.compile("<?!?\\[\\s*(?:end)?if[^]]*\\]>?");
+    private static final Pattern styleUnwantedImport =
+            Pattern.compile("@import(\\s)*((\'|\")?(\\s)*(http://|https://)?([^\\s;]*)(\\s)*(\'|\")?(\\s)*;?)", Pattern.CASE_INSENSITIVE);
 
     private static final Queue<CachedItem> cachedItems = new ConcurrentLinkedQueue<CachedItem>();
 
@@ -178,7 +180,8 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
              *
              */
             if (trimmedHtml.contains("@")) {
-                out = out.append(trimmedHtml);
+                final String trimmedHtmlWithoutImport = styleUnwantedImport.matcher(trimmedHtml).replaceAll("");
+                out = out.append(trimmedHtmlWithoutImport);
             } else {
                 //noinspection deprecation
                 org.apache.xml.serialize.HTMLSerializer serializer = getHTMLSerializer(out, format);

--- a/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
+++ b/src/main/java/org/owasp/validator/html/scan/AntiSamyDOMScanner.java
@@ -69,7 +69,9 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
     private static final Pattern conditionalDirectives =
             Pattern.compile("<?!?\\[\\s*(?:end)?if[^]]*\\]>?");
     private static final Pattern styleUnwantedImport =
-            Pattern.compile("@import(\\s)*((\'|\")?(\\s)*(http://|https://)?([^\\s;]*)(\\s)*(\'|\")?(\\s)*;?)", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("@import(\\s)*(([^;\"'\\(]*((\".*?\")|('.*?')|(\\(.*?\\)))[^;]*?)+?|([^;\"'\\(]*?))(;+?|$)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern styleAllImport =
+            Pattern.compile("@import[^$]*$", Pattern.CASE_INSENSITIVE);
 
     private static final Queue<CachedItem> cachedItems = new ConcurrentLinkedQueue<CachedItem>();
 
@@ -180,7 +182,8 @@ public class AntiSamyDOMScanner extends AbstractAntiSamyScanner {
              *
              */
             if (trimmedHtml.contains("@")) {
-                final String trimmedHtmlWithoutImport = styleUnwantedImport.matcher(trimmedHtml).replaceAll("");
+                String trimmedHtmlWithoutImport = styleUnwantedImport.matcher(trimmedHtml).replaceAll("");
+                trimmedHtmlWithoutImport = styleAllImport.matcher(trimmedHtmlWithoutImport).replaceAll("");
                 out = out.append(trimmedHtmlWithoutImport);
             } else {
                 //noinspection deprecation


### PR DESCRIPTION
**Problem:**
When a html message contains `@import` CSS at-rule within `<style></style>`, the message is not shown sometimes.

**Root cause:**
Sanitizing is skipped when `@` exists within `<style></style>` to accept `@media` on https://github.com/Zimbra/antisamy/pull/2. Then `@import` is also not checked and it is included in GetMsgResponse.

**Change:**
Change to remove `@import` statement from a style, referring the following code:
```
com.zimbra.common.localconfig.DebugConfig
    public static final String defangStyleUnwantedImport = value(
            "defang_style_unwanted_import",
            "@import(\\s)*((\'|\")?(\\s)*(http://|https://)?([^\\s;]*)(\\s)*(\'|\")?(\\s)*;?)");

com.zimbra.cs.html.DefangFilter
    private static final Pattern STYLE_UNWANTED_IMPORT = Pattern.compile(
        DebugConfig.defangStyleUnwantedImport, Pattern.CASE_INSENSITIVE);

     private static String sanitizeStyleValue(String value) {
        //...
        sanitizedValue = STYLE_UNWANTED_IMPORT.matcher(sanitizedValue).replaceAll("");
```